### PR TITLE
Resolve credential path

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -28,7 +28,8 @@ def get_google_sheets_client():
     else:
         # Assumes your downloaded JSON key file is named 'credentials.json'
         # and is in the same folder as this script.
-        client = gspread.service_account(filename='credentials.json')
+        cred_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "credentials.json")
+        client = gspread.service_account(filename=cred_path)
         return client
 
 def is_market_hours():


### PR DESCRIPTION
## Summary
- ensure get_google_sheets_client uses an absolute path to credentials.json

## Testing
- `python -m py_compile scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3233a0580832eb5d363d0bc95b16f